### PR TITLE
FY-110/custom error and handler

### DIFF
--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -9,6 +9,7 @@ from .serializers import (
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework import permissions
+from pong.utils import custom_exception_handler, CustomError, wrap_data
 
 
 class IsOwner(permissions.BasePermission):
@@ -31,18 +32,21 @@ class ProfileViewSet(
         return super().get_permissions()
 
     def retrieve(self, request, *args, **kwargs):
-        instance = self.get_object()
-        if request.user.intra_id != kwargs["intra_id"]:
-            serializer = ProfileNotOwnerSerializer(instance)
-        else:
-            serializer = ProfileSerializer(instance)
-        return Response(
-            DataWrapperSerializer(
-                {"user": serializer.data, "match_history": [{}]},
-                inner_serializer=ProfileResponseSerializer,
-            ).data,
-            status=status.HTTP_200_OK,
-        )
+        try:
+            instance = self.get_object()
+            if request.user.intra_id != kwargs["intra_id"]:
+                serializer = ProfileNotOwnerSerializer(instance)
+            else:
+                serializer = ProfileSerializer(instance)
+            return Response(
+                DataWrapperSerializer(
+                    {"user": serializer.data, "match_history": [{}]},
+                    inner_serializer=ProfileResponseSerializer,
+                ).data,
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            raise e
 
     def update(self, request, *args, **kwargs):
         if "data" in request.data:

--- a/src/authentication/oauthviews.py
+++ b/src/authentication/oauthviews.py
@@ -12,6 +12,7 @@ from accounts.serializers import (
     UserTokenProfileSerializer,
     DataWrapperSerializer,
 )
+from pong.utils import custom_exception_handler, CustomError, wrap_data
 from .models import OAuth
 import requests
 import json
@@ -42,11 +43,7 @@ class OAuthView(APIView):
         try:
             code = request.GET.get("code")
             response = self.request42OAuth(code)
-            if response.status_code != 200:
-                return response
             userData = self.request42UserData(response.json()["access_token"])
-            if userData.status_code != 200:
-                return userData
             user = self.createUserProfileOauth(userData, response)
             token, created = Token.objects.get_or_create(user=user)
             if created:
@@ -56,7 +53,7 @@ class OAuthView(APIView):
                 self.joinUserData(user, token.key), status=status.HTTP_200_OK
             )
         except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+            raise e
 
     def request42OAuth(self, code):
         data = {
@@ -72,7 +69,8 @@ class OAuthView(APIView):
             data=json.dumps(data),
             headers=headers,
         )
-        response.raise_for_status()
+        if response.status_code != 200:
+            raise CustomError(response.text, response.status_code)
         return response
 
     def request42UserData(self, access_token):
@@ -80,7 +78,8 @@ class OAuthView(APIView):
             "https://api.intra.42.fr/v2/me",
             headers={"Authorization": "Bearer " + access_token},
         )
-        userData.raise_for_status()
+        if userData.status_code != 200:
+            raise CustomError(userData.text, userData.status_code)
         return userData
 
     def createUserProfileOauth(self, userData, response):
@@ -95,8 +94,9 @@ class OAuthView(APIView):
         except User.DoesNotExist:
             pass
 
-        serializer = UserSerializer(data=data)
-        if serializer.is_valid():
+        try:
+            serializer = UserSerializer(data=data)
+            serializer.is_valid(raise_exception=True)
             user = serializer.save()
             profile = Profile.objects.create(
                 user=user,
@@ -104,14 +104,18 @@ class OAuthView(APIView):
                 email=data["email"],
                 avator="default.jpg",
             )
-            profile.save()
             oauth = OAuth.objects.create(
                 user=user,
                 access_token=response.json()["access_token"],
                 refresh_token=response.json()["refresh_token"],
                 token_type=response.json()["token_type"],
             )
-            oauth.save()
             return user
-        else:
-            raise ValidationError(serializer.errors)
+        except Exception as e:
+            if user:
+                user.delete()
+            if profile:
+                profile.delete()
+            if oauth:
+                oauth.delete()
+            raise CustomError(str(e), status.HTTP_400_BAD_REQUEST)

--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework import status
 from django.contrib.auth import logout
 from urllib.parse import quote
+from pong.utils import custom_exception_handler, CustomError, wrap_data
 
 
 class LoginView(APIView):
@@ -13,14 +14,8 @@ class LoginView(APIView):
         if request.user.is_authenticated:
             return redirect("http://localhost:8000/oauth/")
         redirect_url = quote(settings.CALLBACK_URL)
-        return Response(
-            {
-                "data": {
-                    "url": f"{settings.OAUTH_URL}?client_id={settings.CLIENT_ID}&redirect_uri={redirect_url}&response_type=code"
-                }
-            },
-            status=status.HTTP_200_OK,
-        )
+        url = f"{settings.OAUTH_URL}?client_id={settings.CLIENT_ID}&redirect_uri={redirect_url}&response_type=code"
+        return Response(wrap_data(url=url), status=status.HTTP_200_OK)
 
 
 class LogoutView(APIView):

--- a/src/pong/settings.py
+++ b/src/pong/settings.py
@@ -159,7 +159,8 @@ AUTH_USER_MODEL = "accounts.User"
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.TokenAuthentication",
-    ]
+    ],
+    "EXCEPTION_HANDLER": "pong.utils.custom_exception_handler",
 }
 
 CLIENT_ID = os.environ.get("CLIENT_ID")

--- a/src/pong/utils.py
+++ b/src/pong/utils.py
@@ -1,0 +1,24 @@
+from rest_framework.views import exception_handler
+from rest_framework.response import Response
+
+
+class CustomError(Exception):
+    def __init__(self, message, status):
+        self.message = message
+        self.status = status
+        super().__init__(self.message)
+
+
+def custom_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+
+    if isinstance(exc, CustomError):
+        return Response({"error": exc.message}, status=exc.status)
+
+    if response is not None:
+        response.data["error"] = str(exc)
+    return response
+
+
+def wrap_data(**kwargs):
+    return {"data": kwargs}


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

<!--
 Write Down related JIRA key and url like this
    [key](issue-url)
 -->

[FY-110](https://idealflower.atlassian.net/browse/FY-110)

## Description
- 에러 Response 형식과 일관성있는 방식으로 수정했습니다.
- CustomError객체에 사용자 정의 에러를 생성할 수 있습니다.
    - rasie CustomError("사용자 정의 메세지, status.HTTP_200_OK)
- def custom_exception_handler(exc, context):
    - 해당 함수를 재정의 해서 DRF에서 에러가 rasie되면 자동으로 작동합니다.
    - CustomError로 인스턴스화된 객체가 들어오면 알맞게 작동합니다.
    - 기본 DRF에러가 rasie되어도 작동합니다.
 - 내부 함수에서 rasie CustomError()를 하고 외부 에서 try/except로 Exception as e로 catch해서 raise e 하면 에러 Response가 클라이언트에게 리턴됩니다.
```
        try:
            code = request.GET.get("code")
            response = self.request42OAuth(code)
            userData = self.request42UserData(response.json()["access_token"])
            user = self.createUserProfileOauth(userData, response)
            token, created = Token.objects.get_or_create(user=user)
            if created:
                token.save()
            login(request, user)
            return Response(
                self.joinUserData(user, token.key), status=status.HTTP_200_OK
            )
        except Exception as e:
            raise e

    def request42OAuth(self, code):
        data = {
            "grant_type": "authorization_code",
            "client_id": settings.CLIENT_ID,
            "client_secret": settings.CLIENT_SECRET,
            "code": code,
            "redirect_uri": settings.CALLBACK_URL,
        }
        headers = {"Content-Type": "application/json"}
        response = requests.post(
            settings.TOKEN_URL,
            data=json.dumps(data),
            headers=headers,
        )
        if response.status_code != 200:
            raise CustomError(response.text, response.status_code)
        return response
```

[FY-110]: https://idealflower.atlassian.net/browse/FY-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ