### PR TITLE
FY-113/User data response when valid

### DIFF
--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -48,6 +48,5 @@ class TokenValidationView(APIView):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         user = UserSerializer(request.user).data
         profile = ProfileSerializer(request.user.profile).data
-        return Response(
-            wrap_data(user=user, profile=profile), status=status.HTTP_200_OK
-        )
+        user.update(profile)
+        return Response(wrap_data(user=user), status=status.HTTP_200_OK)

--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -12,6 +12,7 @@ from pong.utils import (
     wrap_data,
     CookieTokenAuthentication,
 )
+from accounts.serializers import UserSerializer, ProfileSerializer
 
 
 class LoginView(APIView):
@@ -45,4 +46,8 @@ class TokenValidationView(APIView):
     def get(self, request):
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_401_UNAUTHORIZED)
-        return Response(wrap_data(is_valid=True), status=status.HTTP_200_OK)
+        user = UserSerializer(request.user).data
+        profile = ProfileSerializer(request.user.profile).data
+        return Response(
+            wrap_data(user=user, profile=profile), status=status.HTTP_200_OK
+        )


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

<!--
 Write Down related JIRA key and url like this
    [key](issue-url)
 -->

[FY-113](https://idealflower.atlassian.net/browse/FY-113)

## Description
- 프론트엔드의 Token유효성 검사 엔드포인트요청으로 /valid 엔드 포인트 생성
- 유효한 사용자면 사용자 정보와 함께 200 응답
- 유효하지 않으면 401 응답

[FY-113]: https://idealflower.atlassian.net/browse/FY-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ