### PR TITLE
Fy-184/대진표 전달 로직 수정

### DIFF
--- a/src/livegame/SubGameResult.py
+++ b/src/livegame/SubGameResult.py
@@ -16,6 +16,7 @@ class SubGameResult:
         self.sid_a = sid_a
         self.sid_b = sid_b
         self.winner = winner
+        self.ended_time = None
 
     def to_json(self, sid_to_user_data: Dict[str, UserDataCache]) -> dict:
         result = {}


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->

API 명세대로 update_tournament가 가능하게 변경했습니다.
비동기 환경에서 거의 동시에 서브게임들이 끝나는 경우가 있어 SubGameresult에 ended_time을 저장해서 먼전 끝난 게임을 판단할 수 있게 하였습니다.
on_start에서는 하나의 강이 끝나면 rebuild_tournamet를 하고 on_going값을 하나 줄인다음에 emit_update_tournament를 하게 변경했습니다.

결과 적으로 하나의 강에서 마지막에 끝난 서브게임은 emit을 하지않고 모든 서브게임의 결과를 반영한 tournamet_tree를 emit하게됩니다. on_going값 또한 명세에 맞춰서 emit하게 됩니다.

4강을 기준으로 하드코딩이 되어있는 상태입니다.

<!--
 Write Down related JIRA key and url like this
    [key](issue-url)
 -->

[FY-184](https://idealflower.atlassian.net/browse/FY-184)

## PR Checklist

-   [x] I read and included theses actions below

1. I have written documents and tests, if needed.


[FY-184]: https://idealflower.atlassian.net/browse/FY-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ