### PR TITLE
Fy-189/대기방 API Refactor

### DIFF
--- a/src/livegame/GameRoomSession.py
+++ b/src/livegame/GameRoomSession.py
@@ -84,9 +84,20 @@ class GameRoomSession(socketio.AsyncNamespace):
             self.logger.error(f"Error in connect: {e}")
             await self.disconnect(sid)
 
+    # SIO: F>B entered
+    async def on_entered(self, sid, data):
+        self.logger.debug(
+            f"entered {self.namespace} from sid {self.sid_to_user_data[sid].intra_id}"
+        )
+
+        data, sid_list, player_id_list, am_i_host_list = await get_room_data(
+            self.game_room_id
+        )
+        await self.emit_update_room(data, player_id_list, sid_list, am_i_host_list)
+
     # SIO: F>B exited
     async def on_exited(self, sid, data):
-        self.logger.debug(f"exited from sid {sid}")
+        self.logger.debug(f"exited from sid {sid}, data: {data}")
 
         if self.is_playing:
             self.logger.warn(
@@ -94,11 +105,11 @@ class GameRoomSession(socketio.AsyncNamespace):
             )
             return
 
+        intra_id = self.sid_to_user_data[sid].intra_id
         del self.sid_to_user_data[sid]
 
-        player_id = data["my_player_id"]
         data, player_id_list, sid_list, am_i_host_list = await left_game_room(
-            self.game_room_id, player_id
+            self.game_room_id, intra_id
         )
 
         if data.get("destroyed_because", None):
@@ -318,13 +329,6 @@ class GameRoomSession(socketio.AsyncNamespace):
             copy_data["am_i_host"] = am_i_host_list[sid_list.index(sid)]
             await sio.emit("update_room", copy_data, room=sid, namespace=self.namespace)
             self.logger.debug(f"emit update_room: {copy_data}")
-
-    async def on_entered(self, sid, data):
-        self.logger.debug(f"entered from sid {sid}")
-
-        user_intra_id = self.sid_to_user_data[sid].intra_id
-        data = await get_room_data(self.game_room_id, user_intra_id)
-        sio.emit("update_room", data, room=sid, namespace=self.namespace)
 
     async def emit_destroyed(self, cause):
         data = {"t_event": time.time(), "destroyed_because": cause}

--- a/src/livegame/databaseio.py
+++ b/src/livegame/databaseio.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(f"{__package__}.{__name__}")
 
 
 @sync_to_async
-def left_game_room(game_room_id, player_id):
+def left_game_room(game_room_id, intra_id):
     try:
         game_room = GameRoom.objects.prefetch_related(
             Prefetch(
@@ -21,38 +21,36 @@ def left_game_room(game_room_id, player_id):
                 to_attr="ordered_players",
             )
         ).get(id=game_room_id)
-        player = GamePlayer.objects.select_related("user__socket_session").get(
-            id=player_id
-        )
+        logger.debug(f"Player {intra_id} left the game room {game_room_id}")
+        player = GamePlayer.objects.get(game=game_room.game, user=intra_id)
     except (GameRoom.DoesNotExist, GamePlayer.DoesNotExist) as e:
         logger.error(f"Error in left_game_room: {e}")
         return None, None, None, None
 
     game = game_room.game
-    ordered_players = getattr(game, "ordered_players", None)
+    players = getattr(game, "ordered_players", None)
 
     if game_room.host == player.user:
+        logger.debug(f"Host left the game room {game_room_id}")
         game.delete()
         unix_time = time.time()
         data = {"t_event": unix_time, "destroyed_because": "host_left"}
         return data, None, None, None
 
-    ordered_players.remove(player)
+    players.remove(player)
     player.delete()
+    game_room.join_players -= 1
+    game_room.save()
 
-    sid_list = [
-        player.user.socket_session.game_room_session_id for player in ordered_players
-    ]
-    player_id_list = [player.id for player in ordered_players if player.id != player_id]
-    am_i_host_list = [player.user == game_room.host for player in ordered_players]
-
-    data = serialize_game_data(game, game_room, ordered_players)
+    data, sid_list, player_id_list, am_i_host_list = get_data_and_lists_for_update_room(
+        game, game_room, players
+    )
 
     return data, player_id_list, sid_list, am_i_host_list
 
 
 @sync_to_async
-def get_room_data(game_room_id, user_intra_id):
+def get_room_data(game_room_id):
     try:
         game_room = GameRoom.objects.prefetch_related(
             Prefetch(
@@ -62,17 +60,31 @@ def get_room_data(game_room_id, user_intra_id):
             )
         ).get(id=game_room_id)
     except (GameRoom.DoesNotExist, GamePlayer.DoesNotExist) as e:
-        logger.error(f"Error in left_game_room: {e}")
-        return None
+        logger.error(f"Error in get_room_data: {e}")
+        return None, None, None, None
 
     game = game_room.game
-    ordered_players = getattr(game, "ordered_players", None)
-    data = serialize_game_data(game, game_room, ordered_players)
-    my_player_id = game.game_player.get(user__intra_id=user_intra_id).id
-    am_i_host = game_room.host.intra_id == user_intra_id
-    data["my_player_id"] = my_player_id
-    data["am_i_host"] = am_i_host
-    return data
+    players = getattr(game, "ordered_players", None)
+    data, sid_list, player_id_list, am_i_host_list = get_data_and_lists_for_update_room(
+        game, game_room, players
+    )
+
+    return data, sid_list, player_id_list, am_i_host_list
+
+
+def get_data_and_lists_for_update_room(game, game_room, players):
+    try:
+        data = serialize_game_data(game, game_room, players)
+        player_id_list = [player.id for player in players]
+        sid_list = [
+            player.user.socket_session.game_room_session_id for player in players
+        ]
+        am_i_host_list = [player.user == game_room.host for player in players]
+    except Exception as e:
+        logger.error(f"Error in get_data_and_lists_for_update_room: {e}")
+        return None, None, None, None
+
+    return data, sid_list, player_id_list, am_i_host_list
 
 
 def serialize_game_data(game, game_room, players):


### PR DESCRIPTION
## Overview

<!--
    A clear and concise description of what this pr is about.
 -->
- 사용자가 방에서 나가기 처리가 안된 상태에서 다시 대기방에 참가요청을 하면 참가가 가능하게 HTTP API를 수정했습니다.
- on_disconnect를 정의해서 대기중인 방에서 소켓 disconnect시 sid_to_user_data에서 삭제합니다. (프론트엔드에서 대기방 새로고침시 재연결을 해서 sid_to_user에 같은 사용자의 데이터가 다른 sid key값으로 쌓이는 문제가 있었습니다.)
- on_entered를 만들어서 프론트엔드에서 소켓준비가 완료되고 entered 이벤트를 호출합니다.
  - 기존 HTTP API에 있던 emit_update_room을 on_entered에서 일괄적으로 처리하게 리팩토링했습니다.

<!--
 Write Down related JIRA key and url like this
    [key](issue-url)
 -->

[FY-189](https://idealflower.atlassian.net/browse/FY-189)

## PR Checklist

-   [x] I read and included theses actions below

1. I have written documents and tests, if needed.


[FY-189]: https://idealflower.atlassian.net/browse/FY-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ